### PR TITLE
feat: Extend rerender offline prompt

### DIFF
--- a/version_constraint_key
+++ b/version_constraint_key
@@ -1,1 +1,1 @@
-officially-open-owl
+reasonably-relaxed-rattler


### PR DESCRIPTION
<details>
<summary><b>Original issue description</b></summary>

## Re-render offline prompt should ask [y/n All/None]

### Problem
Currently only asks [y/n or All]. If all clips are offline and you want none of them to be re-rendered, you have to keep pressing 'n'. If the next prompt is for final queue confirmation and you're still pressing 'n', you'll have to start again.

### Solution
Add "None" option by:
- Requiring uppercase 'N' for 'None'
- Requiring full words for options ['yes', 'no', 'all', 'none']
- Using an interactive menu instead of a simple confirmation:

```
* Yes
  No
  All
  None
```
</details>

closes #189