### PR TITLE
fix!: Offline handler handling status 'None'

### DIFF
--- a/src/proxima/celery/celery.py
+++ b/src/proxima/celery/celery.py
@@ -30,8 +30,8 @@ app.autodiscover_tasks(
 
 # Remap terms
 broker_settings = {
-    "broker_url": settings.broker.broker_url,
-    "result_backend": settings.broker.broker_url,
+    "broker_url": settings.broker.url,
+    "result_backend": settings.broker.url,
     "result_expires": settings.broker.result_expires,
 }
 

--- a/src/proxima/celery/tasks.py
+++ b/src/proxima/celery/tasks.py
@@ -206,7 +206,7 @@ def encode_proxy(self, job_dict: dict) -> str:
         raise Reject(e, requeue=False)
 
     # Create logfile
-    encode_log_dir = job.settings.paths.ffmpeg_logfile
+    encode_log_dir = job.settings.paths.ffmpeg_logfile_dir
     os.makedirs(encode_log_dir, exist_ok=True)
     logfile_path = os.path.normpath(
         os.path.join(encode_log_dir, job.output_file_name + ".txt")

--- a/src/proxima/cli/queue.py
+++ b/src/proxima/cli/queue.py
@@ -54,9 +54,13 @@ def main():
     media_pool_items = resolve.get_media_pool_items(track_items)
     batch = resolve.generate_batch(media_pool_items, settings)
 
-    batch.remove_already_linked()
+    # 'Remove healthy' runs twice because 'Handle Existing Unlinked'
+    # can make media healthy, ut we also don't want it to
+    # handle healthy media.
+
+    batch.remove_healthy()
     batch.handle_existing_unlinked()
-    batch.remove_already_linked()
+    batch.remove_healthy()
     batch.handle_offline_proxies()
     app_status = AppStatus("proxima")
 

--- a/src/proxima/settings/user_settings.toml
+++ b/src/proxima/settings/user_settings.toml
@@ -8,8 +8,8 @@
   version_constrain = true # DANGEROUS! If false, allows any version of worker to take jobs.
 
 [paths]
-  proxy_path_root = "R:/ProxyMedia"  # Proxy media retains source folder structure
-  ffmpeg_logfile_path = "R:/ProxyMedia/@logs"
+  proxy_root = "R:/ProxyMedia"  # Proxy media retains source folder structure
+  ffmpeg_logfile_dir = "R:/ProxyMedia/@logs"
   linkable_proxy_suffix_regex = [ "-\\d", "_\\d", "S\\d*" ] # -1, # _1, #_S001 respectively
 
 [proxy]

--- a/src/proxima/types/batch.py
+++ b/src/proxima/types/batch.py
@@ -157,8 +157,9 @@ class Batch:
 
         return data
 
-    def remove_already_linked(self):
-        self.batch = [x for x in self.batch if not x.is_linked]
+    def remove_healthy(self):
+        """Remove linked and online source media, i.e. \"healthy\" """
+        self.batch = [x for x in self.batch if not x.is_linked or x.is_offline]
 
     def handle_existing_unlinked(self):
         """

--- a/src/proxima/types/batch.py
+++ b/src/proxima/types/batch.py
@@ -89,7 +89,7 @@ class Batch:
         return str(
             f"[cyan]{self.project} | {self.timeline}[/]\n"
             f"[green]Linked {els} | [yellow]Requeued {elr} | [red]Failed {elf}\n"
-            f"{settings.proxy.preset_nickname} | {overwrite_warning}\n"
+            f"{settings.proxy.nickname} | {overwrite_warning}\n"
             f"\n[bold][white]Total queueable now:[/bold] {len(self.batch)}\n"
         )
 

--- a/src/proxima/types/batch.py
+++ b/src/proxima/types/batch.py
@@ -163,81 +163,85 @@ class Batch:
 
     def handle_existing_unlinked(self):
         """
-        Prompts user to either link or re-render unlinked proxy media that exists in the expected location.
+        Prompts to link or re-render existing but unlinked media.
         """
 
         logger.info("[cyan]Checking for existing, unlinked media...")
+        existing_unlinked, mismatch_fail, link_success = [], [], []
 
-        existing_unlinked = []
-        mismatch_fail = []
-        link_success = []
+        if not self.batch:
+            raise ValueError("No batch to handle!")
 
-        if self.batch:
-            existing_unlinked = [
-                x for x in self.batch if not x.is_linked and x.newest_linkable_proxy
-            ]
+        existing_unlinked = [
+            x for x in self.batch if not x.is_linked and x.newest_linkable_proxy
+        ]
 
-        # Set media handled now to 'Online' so the offline handler doesn't catch it
+        # Exit early if none
+        if not len(existing_unlinked) > 0:
+            logger.debug("[magenta]No existing unlinked media detected.")
+            return
+
+        # 'Online' handled media so the offline handler doesn't catch it
         for x in self.batch:
             if x in existing_unlinked:
                 x.is_offline = False
 
-        if len(existing_unlinked) > 0:
-            # Log each existing unlinked media and matched proxy source with abbreviated file path
-            for x in existing_unlinked:
-                logger.debug(
-                    f"[magenta] * Existing unlinked - '{x.source.file_name}' <-> {(core.shorten_long_path(x.newest_linkable_proxy))}"
+        # Log with abbreviated file paths
+        for x in existing_unlinked:
+            logger.debug(
+                f"[magenta] * Existing unlinked - '{x.source.file_name}' <-> {(core.shorten_long_path(x.newest_linkable_proxy))}"
+            )
+
+        # Prompt user to relink or rerender
+        if not Confirm.ask(
+            f"\n[yellow][bold]{len(existing_unlinked)} source files have existing but unlinked proxy media.\n"
+            "[/bold]Would you like to link them? If not they will be re-rendered."
+        ):
+            # Mark all as requeued and carry on
+            self.existing_link_requeued_count = len(existing_unlinked)
+
+            if settings.proxy.overwrite:
+                logger.debug("[magenta] * Existing proxies set to be overwritten")
+                # TODO: Implement overwrite logic
+                # also need to test for oplock issues"
+            return
+
+        # Handle linking
+        from rich.progress import track
+
+        for job in track(
+            existing_unlinked, description="[cyan]Linking...", transient=True
+        ):
+            if not job.newest_linkable_proxy:
+                continue
+
+            try:
+                job.link_proxy(job.newest_linkable_proxy)
+            except exceptions.ResolveLinkMismatchError:
+                mismatch_fail.append(job)
+                logger.error(
+                    f"[red]Failed to link '{os.path.basename(job.newest_linkable_proxy)}' - proxy does not match source!"
                 )
+            else:
+                link_success.append(job)
+                self.batch.remove(job)
 
-            # Prompt user to relink or rerender
+        # Mark any successful links
+        self.existing_link_success_count = len(link_success)
+
+        # Prompt to requeue any failed links
+        if mismatch_fail:
             if not Confirm.ask(
-                f"\n[yellow][bold]{len(existing_unlinked)} source files have existing but unlinked proxy media.\n"
-                "[/bold]Would you like to link them? If not they will be re-rendered."
+                f"[yellow]{len(mismatch_fail)} existing proxies failed to link.\n"
+                "They may be corrupt or incomplete. Re-render them?"
             ):
-                # Mark all as requeued and carry on
-                self.existing_link_requeued_count = len(existing_unlinked)
-
-                if settings.proxy.overwrite:
-                    logger.debug("[magenta] * Existing proxies set to be overwritten")
-                    # TODO: Implement overwrite logic - also need to test if this is feasible without oplock issues"
+                # Mark failed links as failed and remove
+                [self.batch.remove(x) for x in mismatch_fail]
+                self.existing_link_failed_count = len(mismatch_fail)
                 return
 
-            # Handle linking
-            from rich.progress import track
-
-            for job in track(
-                existing_unlinked, description="[cyan]Linking...", transient=True
-            ):
-                if not job.newest_linkable_proxy:
-                    continue
-
-                try:
-                    job.link_proxy(job.newest_linkable_proxy)
-                except exceptions.ResolveLinkMismatchError:
-                    mismatch_fail.append(job)
-                    logger.error(
-                        f"[red]Failed to link '{os.path.basename(job.newest_linkable_proxy)}' - proxy does not match source!"
-                    )
-                else:
-                    link_success.append(job)
-                    self.batch.remove(job)
-
-            # Mark any successful links
-            self.existing_link_success_count = len(link_success)
-
-            # Prompt to requeue any failed links
-            if mismatch_fail:
-                if not Confirm.ask(
-                    f"[yellow]{len(mismatch_fail)} existing proxies failed to link. "
-                    + "They may be corrupt or incomplete. Re-render them?"
-                ):
-                    # Mark failed links as failed and remove
-                    [self.batch.remove(x) for x in mismatch_fail]
-                    self.existing_link_failed_count = len(mismatch_fail)
-                    return
-
-                # Mark failed links as requeued, not offline
-                self.existing_link_requeued_count += len(mismatch_fail)
+            # Mark failed links as requeued, not offline
+            self.existing_link_requeued_count += len(mismatch_fail)
 
     def handle_offline_proxies(self):
         """Prompt to rerender proxies that are 'linked' but their media does not exist.
@@ -246,7 +250,7 @@ class Batch:
         This prompt can warn users to find that media if it's missing, or rerender if intentionally unavailable.
         """
 
-        logger.info(f"[cyan]Checking for offline proxies...")
+        logger.info("[cyan]Checking for offline proxies...")
 
         offline_proxies = []
 

--- a/src/proxima/types/job.py
+++ b/src/proxima/types/job.py
@@ -151,7 +151,7 @@ class Job:
     def is_linked(self) -> bool:
         """Job with linked media that may or may not be \"Offline\" """
 
-        if self.source.proxy_status in ["None", "Offline"]:
+        if self.source.proxy_status == "None":
             return False
         return True
 

--- a/src/proxima/types/job.py
+++ b/src/proxima/types/job.py
@@ -190,15 +190,24 @@ class Job:
         # Fetch paths of all possible variants of source filename
         matches = glob(glob_path + "*.*")
 
+        if not matches:
+            logger.debug(
+                f'[magenta] * No variants found at expected path:\n   "{glob_path}"'
+            )
+            return
+
         candidates = []
         for x in matches:
-            # If exact match
+            logger.debug(f"[magenta] * Checking variant {x}")
+
+            logger.debug("[magenta] * Checking for exact match")
             if os.path.basename(x).upper() == self.source.file_name.upper():
                 logger.debug(f"[magenta] * Found exact match: '{os.path.basename(x)}'")
                 candidates.append(x)
                 continue
 
             # If match allowed suffix
+            logger.debug("[magenta] * Checking for regex match")
             basename = os.path.basename(x)
             candidate_filename = os.path.splitext(basename)[0]
             for criteria in self.settings.paths.linkable_proxy_suffix_regex:

--- a/src/proxima/types/job.py
+++ b/src/proxima/types/job.py
@@ -157,9 +157,8 @@ class Job:
 
     @property
     def is_offline(self) -> bool:
-        """Whether or not the job has offline proxy media"""
-
-        return self.managed_proxy_status
+        """Job with \"Offline\" linked media"""
+        return self.proxy_offline_status
 
     @is_offline.setter
     def is_offline(self, value: bool):

--- a/src/proxima/types/job.py
+++ b/src/proxima/types/job.py
@@ -149,7 +149,7 @@ class Job:
 
     @property
     def is_linked(self) -> bool:
-        """Whether or not the job has linked proxy media"""
+        """Job with linked media that may or may not be \"Offline\" """
 
         if self.source.proxy_status in ["None", "Offline"]:
             return False

--- a/src/proxima/types/job.py
+++ b/src/proxima/types/job.py
@@ -57,8 +57,8 @@ class Job:
         self.settings = settings
 
         # Dynamic values
-        self.managed_proxy_status: bool = (
-            False if self.source.proxy_status == "Offline" else True
+        self.proxy_offline_status: bool = (
+            True if self.source.proxy_status == "Offline" else False
         )
 
     def __repr__(self):

--- a/src/proxima/types/job.py
+++ b/src/proxima/types/job.py
@@ -165,8 +165,8 @@ class Job:
         """Offline proxy media status setter"""
 
         assert isinstance(value, bool)
-        self.managed_proxy_status = value
-        return self.managed_proxy_status
+        self.proxy_offline_status = value
+        return self.proxy_offline_status
 
     @cached_property
     def newest_linkable_proxy(self) -> str | None:


### PR DESCRIPTION
Offline handler was incorrectly handling unlinked footage as 'offline'.

Another issue appeared causing existing unlinked proxies not being identified. Turned out to be some key settings in TOML config were named incorrectly and silently fell back to Pydantic defaults.

BREAKING CHANGE: Rename incorrect configuration keys, remove Pydantic defaults